### PR TITLE
Moved module description to DescriptionAttribute of module

### DIFF
--- a/docs/tutorials/ServerModule/ServerModule.md
+++ b/docs/tutorials/ServerModule/ServerModule.md
@@ -36,6 +36,7 @@ For the following properties and attributes reference these files:
 
 ````cs
 [ServerModule(ModuleName)]
+[Description("Example description")]
 public class ModuleController : ServerModuleBase<ModuleConfig>
 {
     internal const string ModuleName = "ExampleName";
@@ -161,34 +162,6 @@ The module console provides a command line interface to interact with the server
 [ServerModuleConsole]
 internal class ModuleConsole : IServerModuleConsole
 {
-    public string ExportDescription(DescriptionExportFormat format)
-    {
-        switch (format)
-        {
-            case DescriptionExportFormat.Console:
-                return ExportConsoleDescription();
-            case DescriptionExportFormat.Documentation:
-                return ExportHtmlDescription();
-        }
-        return string.Empty;
-    }
-
-    // Export your description for the developer console here
-    // This should represent the current state
-    private string ExportConsoleDescription()
-    {
-        var manPage = @"Little module for little test";
-        return manPage;
-    }
-
-    // Export your description for the supervisor or maintenance
-    // This should be a static explanation of the plugin
-    private string ExportHtmlDescription()
-    {
-        var manPage = @"Little module for little test";
-        return manPage;
-    }
-
     public void ExecuteCommand(string[] args, Action<string> outputStream)
     {
         if (!args.Any())

--- a/src/DependentTestModule/ModuleController/ModuleConsole.cs
+++ b/src/DependentTestModule/ModuleController/ModuleConsole.cs
@@ -4,9 +4,7 @@
 using System;
 using System.ComponentModel;
 using Moryx.Logging;
-using Moryx.Runtime;
 using Moryx.Runtime.Modules;
-using Moryx.Serialization;
 
 namespace Moryx.DependentTestModule
 {
@@ -18,42 +16,6 @@ namespace Moryx.DependentTestModule
         public IModuleLogger Logger { get; set; }
 
         #endregion
-
-        public string ExportDescription(DescriptionExportFormat format)
-        {
-            switch (format)
-            {
-                case DescriptionExportFormat.Console:
-                    return ExportConsoleDescription();
-
-                case DescriptionExportFormat.Documentation:
-                    return ExportHtmlDescription();
-            }
-
-            return string.Empty;
-        }
-
-        // Export your desription for the developer console here
-        // This should represent the current state
-        private string ExportConsoleDescription()
-        {
-            var manPage =
-@"
-Test module for System tests
-";
-            return manPage;
-        }
-
-        // Export your desription for the supervisor or maintenance
-        // This should be a static explaination of the plugin
-        private string ExportHtmlDescription()
-        {
-            var manPage =
-@"
-Test module for System tests
-";
-            return manPage;
-        }
 
         public void ExecuteCommand(string[] args, Action<string> outputStream)
         {

--- a/src/DependentTestModule/ModuleController/ModuleController.cs
+++ b/src/DependentTestModule/ModuleController/ModuleController.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System;
+using System.ComponentModel;
 using System.Threading;
 using Moryx.Runtime.Container;
 using Moryx.Runtime.Modules;
@@ -10,6 +10,7 @@ using Moryx.TestModule;
 namespace Moryx.DependentTestModule
 {
     [ServerModule(ModuleName)]
+    [Description("Test module for System tests")]
     public class ModuleController : ServerModuleFacadeControllerBase<ModuleConfig>, IFacadeContainer<IDependentTestModule>
     {
         public const string ModuleName = "DependentTestModule";

--- a/src/Moryx.Runtime.Kernel/RunMode/Command/Commands/ConsoleCommand.cs
+++ b/src/Moryx.Runtime.Kernel/RunMode/Command/Commands/ConsoleCommand.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Moryx.Container;
 using Moryx.Runtime.Modules;
+using Moryx.Tools;
 
 namespace Moryx.Runtime.Kernel
 {
@@ -14,7 +15,7 @@ namespace Moryx.Runtime.Kernel
         public IModuleManager ModuleManager { get; set; }
 
         /// <summary>
-        /// Check if this 
+        /// Check if this
         /// </summary>
         public bool CanHandle(string command)
         {
@@ -57,13 +58,13 @@ namespace Moryx.Runtime.Kernel
             var console = module.Console;
 
             if (fullCommand[0] == "man")
-                Console.Write(console.ExportDescription(DescriptionExportFormat.Console));
+                Console.WriteLine(module.GetType().GetDescription());
             else
                 console.ExecuteCommand(fullCommand.Skip(2).ToArray(), Console.WriteLine);
         }
 
         /// <summary>
-        /// Opens the module specific console 
+        /// Opens the module specific console
         /// </summary>
         /// <param name="module">The module.</param>
         private void ModuleSpecificConsole(IServerModule module)
@@ -82,7 +83,7 @@ namespace Moryx.Runtime.Kernel
                 switch (command)
                 {
                     case "help":
-                        Console.WriteLine(console.ExportDescription(DescriptionExportFormat.Console));
+                        Console.WriteLine(module.GetType().GetDescription());
                         break;
                     case "quit":
                     case "bye":

--- a/src/Moryx.Runtime.Maintenance/ModuleController/ModuleConsole.cs
+++ b/src/Moryx.Runtime.Maintenance/ModuleController/ModuleConsole.cs
@@ -2,13 +2,8 @@
 // Licensed under the Apache License, Version 2.0
 
 using System;
-using System.Linq;
-using System.Reflection;
 using Moryx.Container;
-using Moryx.Model;
-using Moryx.Runtime.Maintenance.Contracts;
 using Moryx.Runtime.Modules;
-using Moryx.Serialization;
 
 namespace Moryx.Runtime.Maintenance
 {
@@ -16,46 +11,6 @@ namespace Moryx.Runtime.Maintenance
     internal class ModuleConsole : IServerModuleConsole
     {
         public IContainer Container { get; set; }
-
-        public string ExportDescription(DescriptionExportFormat format)
-        {
-            switch (format)
-            {
-                case DescriptionExportFormat.Console:
-                    return ExportConsoleDescription();
-                case DescriptionExportFormat.Documentation:
-                    return ExportHtmlDescription();
-            }
-            return string.Empty;
-        }
-
-        private string ExportConsoleDescription()
-        {
-            if (Container == null)
-                return "Man page only available if plugin is in state Ready or Running";
-
-            var modules = Container.GetRegisteredImplementations(typeof(IMaintenancePlugin));
-            var names = modules.Select(type => "* " + type.GetCustomAttribute<PluginAttribute>().Name);
-            var manPage = $@"
-   Maintenance Module - Bundle Maintenance
-   Version: {GetType().Assembly.GetName().Version}
----------------------------------------------
-This module provides maintenance access to all
-module including itself. It is plugin based
-and can be extended and customized. 
-
-Available plugins:
-{string.Join("\n", names)}
-  
-";
-            return manPage;
-        }
-
-        private string ExportHtmlDescription()
-        {
-            return "Core module to maintain the application. It provides config and logging support by default. Database configuration can be " +
-                   "included with an additional plugin as well as other extensions implementing IMaintenanceModule";
-        }
 
         public void ExecuteCommand(string[] args, Action<string> outputStream)
         {

--- a/src/Moryx.Runtime.Maintenance/ModuleController/ModuleController.cs
+++ b/src/Moryx.Runtime.Maintenance/ModuleController/ModuleController.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using Moryx.Logging;
 using Moryx.Model;
@@ -18,6 +19,8 @@ namespace Moryx.Runtime.Maintenance
     /// Maintenance module that hosts the plugins.
     /// </summary>
     [ServerModule(ModuleName)]
+    [Description("Core module to maintain the application. It provides config, database and logging support by default. " +
+                 "Additional plugins can be included as well as other extensions implementing IMaintenanceModule")]
     public class ModuleController : ServerModuleBase<ModuleConfig>, IPlatformModule
     {
         internal const string ModuleName = "Maintenance";
@@ -91,7 +94,7 @@ namespace Moryx.Runtime.Maintenance
                 var baseType = unconfiguredPlugin.GetType().BaseType;
                 if (baseType == null || !typeof(MaintenancePluginBase<,>).IsAssignableFrom(baseType.GetGenericTypeDefinition()))
                     throw new ArgumentException("MaintenancePlugins should be of type MaintenancePluginBase");
-                
+
                 var configType = baseType.GetGenericArguments()[0];
 
                 var pluginConfig = (MaintenancePluginConfig)Activator.CreateInstance(configType);

--- a/src/Moryx.Runtime/Modules/IServerModuleConsole.cs
+++ b/src/Moryx.Runtime/Modules/IServerModuleConsole.cs
@@ -11,33 +11,10 @@ namespace Moryx.Runtime.Modules
     public interface IServerModuleConsole
     {
         /// <summary>
-        /// Export the description of this module
-        /// </summary>
-        /// <param name="format">Descirption format</param>
-        /// <returns>Formatted description string</returns>
-        string ExportDescription(DescriptionExportFormat format);
-
-        /// <summary>
         /// Pass a command to this module
         /// </summary>
         /// <param name="args">Arguments passed to the module</param>
         /// <param name="outputStream">Output stream to be used for feedback</param>
         void ExecuteCommand(string[] args, Action<string> outputStream);
-    }
-
-    /// <summary>
-    /// Format for the description export
-    /// </summary>
-    public enum DescriptionExportFormat
-    {
-        /// <summary>
-        /// Print module description to developer console. This might include runtime specific information.
-        /// </summary>
-        Console,
-
-        /// <summary>
-        /// Print module description to be used for general documentation
-        /// </summary>
-        Documentation,
     }
 }

--- a/src/TestModule/ModuleController/ModuleConsole.cs
+++ b/src/TestModule/ModuleController/ModuleConsole.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.ComponentModel;
-using Moryx.Runtime;
 using Moryx.Runtime.Modules;
-using Moryx.Serialization;
 using IContainer = Moryx.Container.IContainer;
 
 namespace Moryx.TestModule
@@ -62,52 +60,9 @@ namespace Moryx.TestModule
     {
         public IContainer Container { get; set; }
 
-        public string ExportDescription(DescriptionExportFormat format)
-        {
-            switch (format)
-            {
-                case DescriptionExportFormat.Console:
-                    return ExportConsoleDescription();
-
-                case DescriptionExportFormat.Documentation:
-                    return ExportHtmlDescription();
-            }
-
-            return string.Empty;
-        }
-
-        // Export your desription for the developer console here
-        // This should represent the current state
-        private string ExportConsoleDescription()
-        {
-            var manPage =
-@"
-Test module for System tests
-";
-            return manPage;
-        }
-
-        // Export your desription for the supervisor or maintenance
-        // This should be a static explaination of the plugin
-        private string ExportHtmlDescription()
-        {
-            var manPage =
-@"
-Test module for System tests
-";
-            return manPage;
-        }
-
         public void ExecuteCommand(string[] args, Action<string> outputStream)
         {
             outputStream("The TestModule does not provide any commands!");
-        }
-
-
-        [EditorBrowsable, Description("Shows the description of this module.")]
-        public string ModuleDescription()
-        {
-            return ExportHtmlDescription();
         }
 
         [EditorBrowsable, Description("Returns the string that was sent.")]

--- a/src/TestModule/ModuleController/ModuleController.cs
+++ b/src/TestModule/ModuleController/ModuleController.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System.ComponentModel;
 using System.Threading;
 using Moryx.Container;
 using Moryx.Model;
@@ -11,6 +12,7 @@ using Moryx.TestTools.Test.Model;
 namespace Moryx.TestModule
 {
     [ServerModule(ModuleName)]
+    [Description("Test module for System tests")]
     public class ModuleController : ServerModuleFacadeControllerBase<ModuleConfig>, IFacadeContainer<ITestModule>
     {
         public const string ModuleName = "TestModule";


### PR DESCRIPTION
Our modules have an option to export console or HTML description, which was intended for the supervision, but never properly used. I removed the complete description and added support for the `DescriptionAttribute` on server modules.

Special help command should be introduced in #30 