### PR TITLE
Use ReflectionTool APIs to create repository instances

### DIFF
--- a/src/Moryx.TestTools.Test.Model/API/IHouseEntityRepository.cs
+++ b/src/Moryx.TestTools.Test.Model/API/IHouseEntityRepository.cs
@@ -12,7 +12,7 @@ namespace Moryx.TestTools.Test.Model
         ICollection<HouseEntity> GetMethLabratories();
     }
 
-    public class HouseEntityRepository : Repository<HouseEntity>, IHouseEntityRepository
+    public class HouseEntityRepository : ModificationTrackedRepository<HouseEntity>, IHouseEntityRepository
     {
         public virtual ICollection<HouseEntity> GetMethLabratories()
         {

--- a/src/Moryx.TestTools.Test.Model/API/ISportCarRepository.cs
+++ b/src/Moryx.TestTools.Test.Model/API/ISportCarRepository.cs
@@ -11,7 +11,7 @@ namespace Moryx.TestTools.Test.Model
         SportCarEntity GetSingleBy(string name);
     }
 
-    public class SportCarRepository : Repository<SportCarEntity>, ISportCarRepository
+    public class SportCarRepository : ModificationTrackedRepository<SportCarEntity>, ISportCarRepository
     {
         public virtual SportCarEntity GetSingleBy(string name)
         {


### PR DESCRIPTION
After merging #28, I wanted to close #4 and noticed a hint about using the constructor delegate to speed up instance creation compared to `Activator`.

I also replaced `IsAssignableFrom` with a direct type comparison for two reasons:
1. It's faster
2. Requesting a base type, e.g. `IRepository` would have returned any repository

To still offer the choice between `GetRepository<ICarEntityRepository>()` and `GetRepository<IRepository<CarEntity>>()`, the repository proxy constructor is registered under both types.