### PR TITLE
Restored implementation of GetEntity for UnitOfWork

### DIFF
--- a/src/Moryx.Model/Extensions/UnitOfWorkExtensions.cs
+++ b/src/Moryx.Model/Extensions/UnitOfWorkExtensions.cs
@@ -13,19 +13,18 @@ namespace Moryx.Model
         /// <summary>
         /// Get or create an entity for a business object
         /// </summary>
-        /// <param name="openContext">An open database context</param>
+        /// <param name="unitOfWork">An open database unit of work</param>
         /// <param name="obj">The business object</param>
         /// <typeparam name="TEntity">The entity type to use</typeparam>
-        public static TEntity GetEntity<TEntity>(this IUnitOfWork openContext, IPersistentObject obj)
+        public static TEntity GetEntity<TEntity>(this IUnitOfWork unitOfWork, IPersistentObject obj)
             where TEntity : class, IEntity
         {
-            var dbSet = openContext.DbContext.Set<TEntity>();
-            var entity = dbSet.GetByKey(obj.Id);
+            var repository = unitOfWork.GetRepository<IRepository<TEntity>>();
+            var entity = repository.GetByKey(obj.Id);
 
             if (entity == null)
             {
-                entity = dbSet.Create();
-                dbSet.Add(entity);
+                entity = repository.Create();
                 EntityIdListener.Listen(entity, obj);
             }
 

--- a/src/Moryx.Model/Repositories/UnitOfWorkFactory.cs
+++ b/src/Moryx.Model/Repositories/UnitOfWorkFactory.cs
@@ -18,7 +18,7 @@ namespace Moryx.Model.Repositories
         /// <summary>
         /// Manager that does the real work
         /// </summary>
-        private IDbContextManager _manager;
+        private readonly IDbContextManager _manager;
 
         private readonly RepositoryProxyBuilder _proxyBuilder = new RepositoryProxyBuilder();
         private readonly IDictionary<Type, Func<Repository>> _repositories = new Dictionary<Type, Func<Repository>>();


### PR DESCRIPTION
Thanks to #31 the `GetEntity` method could be restored to only work on repository and unit of work instead of the DbContext. This is much more simple to mock in tests.