### PR TITLE
Execute ModelSetups with IUnitOfWork instead of DbContext

### DIFF
--- a/src/Moryx.Model.InMemory/InMemoryDbContextManager.cs
+++ b/src/Moryx.Model.InMemory/InMemoryDbContextManager.cs
@@ -11,16 +11,25 @@ namespace Moryx.Model.InMemory
     /// <summary>
     /// In memory implementation of the <see cref="IDbContextManager"/>
     /// </summary>
-    public class InMemoryDbContextManager : IDbContextManager
+    public sealed class InMemoryDbContextManager : IDbContextManager
     {
         private readonly string _instanceId;
 
+        /// <inheritdoc />
         public IReadOnlyCollection<IModelConfigurator> Configurators => Array.Empty<IModelConfigurator>();
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="InMemoryDbContextManager"/>.
+        /// A memory persistent factory will be created without any instance id.
+        /// </summary>
         public InMemoryDbContextManager() : this(string.Empty)
         {
         }
 
+        /// <summary>
+        /// Creates a new instance of the <see cref="InMemoryDbContextManager"/>.
+        /// A memory persistent factory will be created with the given instance id.
+        /// </summary>
         public InMemoryDbContextManager(string instanceId)
         {
             _instanceId = instanceId;

--- a/src/Moryx.Model.InMemory/InMemoryDbContextManager.cs
+++ b/src/Moryx.Model.InMemory/InMemoryDbContextManager.cs
@@ -14,10 +14,7 @@ namespace Moryx.Model.InMemory
     public sealed class InMemoryDbContextManager : IDbContextManager
     {
         private readonly string _instanceId;
-
-        /// <inheritdoc />
-        public IReadOnlyCollection<IModelConfigurator> Configurators => Array.Empty<IModelConfigurator>();
-
+        
         /// <summary>
         /// Creates a new instance of the <see cref="InMemoryDbContextManager"/>.
         /// A memory persistent factory will be created without any instance id.
@@ -33,6 +30,21 @@ namespace Moryx.Model.InMemory
         public InMemoryDbContextManager(string instanceId)
         {
             _instanceId = instanceId;
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyCollection<Type> Contexts => Array.Empty<Type>();
+
+        /// <inheritdoc />
+        public IModelConfigurator GetConfigurator(Type contextType)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public IModelSetupExecutor GetSetupExecutor(Type contextType)
+        {
+            throw new NotImplementedException();
         }
 
         /// <inheritdoc />

--- a/src/Moryx.Model.InMemory/InMemoryUnitOfWorkFactory.cs
+++ b/src/Moryx.Model.InMemory/InMemoryUnitOfWorkFactory.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System.Data.Entity;
+using Moryx.Model.Configuration;
+using Moryx.Model.Repositories;
+
+namespace Moryx.Model.InMemory
+{
+    /// <summary>
+    /// In memory implementation of the <see cref="IUnitOfWorkFactory{TContext}"/>
+    /// </summary>
+    public sealed class InMemoryUnitOfWorkFactory<TContext> : IUnitOfWorkFactory<TContext>
+        where TContext : DbContext
+    {
+        private readonly IUnitOfWorkFactory<TContext> _internalFactory;
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="InMemoryUnitOfWorkFactory{TContext}"/>.
+        /// A memory persistent factory will be created without any instance id.
+        /// </summary>
+        public InMemoryUnitOfWorkFactory() : this(string.Empty)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="InMemoryUnitOfWorkFactory{TContext}"/>.
+        /// A memory persistent factory will be created with the given instance id.
+        /// </summary>
+        public InMemoryUnitOfWorkFactory(string instanceId)
+        {
+            _internalFactory = new UnitOfWorkFactory<TContext>(new InMemoryDbContextManager(instanceId));
+        }
+
+        /// <inheritdoc />
+        public IUnitOfWork<TContext> Create() =>
+            _internalFactory.Create();
+
+        /// <inheritdoc />
+        public IUnitOfWork<TContext> Create(IDatabaseConfig config) =>
+            _internalFactory.Create(config);
+
+        /// <inheritdoc />
+        public IUnitOfWork<TContext> Create(ContextMode contextMode) =>
+            _internalFactory.Create(contextMode);
+
+        /// <inheritdoc />
+        public IUnitOfWork<TContext> Create(IDatabaseConfig config, ContextMode contextMode) =>
+            _internalFactory.Create(config, contextMode);
+    }
+}

--- a/src/Moryx.Model.InMemory/Moryx.Model.InMemory.csproj
+++ b/src/Moryx.Model.InMemory/Moryx.Model.InMemory.csproj
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Moryx.Model.InMemory.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Moryx.Model.InMemory.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Effort, Version=2.2.10.0, Culture=neutral, PublicKeyToken=6a46696d54971e6d, processorArchitecture=MSIL">
@@ -61,6 +63,7 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="InMemoryDbContextManager.cs" />
+    <Compile Include="InMemoryUnitOfWorkFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Moryx.Model.PostgreSQL/NpgsqlModelConfigurator.cs
+++ b/src/Moryx.Model.PostgreSQL/NpgsqlModelConfigurator.cs
@@ -57,7 +57,7 @@ namespace Moryx.Model.PostgreSQL
         /// <inheritdoc />
         public override void DumpDatabase(IDatabaseConfig config, string targetPath)
         {
-            var dumpName = $"{DateTime.Now:dd-MM-yyyy-hh-mm-ss}_{TargetModel}_{config.Database}.backup";
+            var dumpName = $"{DateTime.Now:dd-MM-yyyy-hh-mm-ss}_{""}_{config.Database}.backup";
             var fileName = Path.Combine(targetPath, dumpName);
 
             Logger.Log(LogLevel.Debug, "Starting to dump database with pg_dump to: {0}", fileName);

--- a/src/Moryx.Model/Configuration/ModelConfiguratorBase.cs
+++ b/src/Moryx.Model/Configuration/ModelConfiguratorBase.cs
@@ -11,7 +11,6 @@ using System.Data.Entity.Migrations.Infrastructure;
 using System.Linq;
 using Moryx.Configuration;
 using Moryx.Logging;
-using Moryx.Tools;
 
 namespace Moryx.Model.Configuration
 {
@@ -22,11 +21,9 @@ namespace Moryx.Model.Configuration
         where TConfig : class, IDatabaseConfig, new()
     {
         private IConfigManager _configManager;
-        private IDictionary<Type, IModelSetup> _setupDict;
         private string _configName;
         private DbMigrationsConfiguration _migrationsConfiguration;
         private string[] _migrations;
-        private Type _contextType;
 
         /// <summary>
         /// Logger for this model configurator
@@ -42,12 +39,15 @@ namespace Moryx.Model.Configuration
         public IDatabaseConfig Config { get; private set; }
 
         /// <inheritdoc />
+        public Type ContextType { get; private set; }
+
+        /// <inheritdoc />
         public string TargetModel { get; private set; }
 
         /// <inheritdoc />
         public void Initialize(Type contextType, IConfigManager configManager, IModuleLogger logger)
         {
-            _contextType = contextType;
+            ContextType = contextType;
             _configManager = configManager;
 
             // Add logger
@@ -69,14 +69,6 @@ namespace Moryx.Model.Configuration
 
             // Load local migrations
             _migrations = GetAvailableMigrations();
-
-            // Load ModelSetups TODO: Load internals
-            _setupDict = ReflectionTool.GetPublicClasses<IModelSetup>(delegate(Type type)
-            {
-                // Try to read context from attribute
-                var setupAttr = type.GetCustomAttribute<ModelSetupAttribute>();
-                return setupAttr != null && setupAttr.TargetContext == _contextType;
-            }).ToDictionary(t => t, t => (IModelSetup) null);
         }
 
         /// <inheritdoc />
@@ -88,7 +80,7 @@ namespace Moryx.Model.Configuration
         /// <inheritdoc />
         public DbContext CreateContext(IDatabaseConfig config, ContextMode mode)
         {
-            var context = (DbContext)Activator.CreateInstance(_contextType, BuildConnectionString(config));
+            var context = (DbContext)Activator.CreateInstance(ContextType, BuildConnectionString(config));
             context.SetContextMode(mode);
             return context;
         }
@@ -248,35 +240,6 @@ namespace Moryx.Model.Configuration
         /// <inheritdoc />
         public abstract void RestoreDatabase(IDatabaseConfig config, string filePath);
 
-        /// <inheritdoc />
-        public IEnumerable<IModelSetup> GetAllSetups() => GetOrCreateFromTypeDict(_setupDict);
-
-        /// <inheritdoc />
-        public void Execute(IDatabaseConfig config, IModelSetup setup, string setupData)
-        {
-            var context = CreateContext(config, ContextMode.AllOn);
-            setup.Execute(context, setupData);
-        }
-
-        /// <summary>
-        /// Creates the instance from the given IDictionary{Type, object}
-        /// </summary>
-        private static IEnumerable<T> GetOrCreateFromTypeDict<T>(IDictionary<Type, T> dict)
-        {
-            foreach (var type in dict.Keys.ToArray())
-            {
-                if (dict[type] == null)
-                {
-                    dict[type] = (T)Activator.CreateInstance(type);
-                    yield return dict[type];
-                }
-                else
-                {
-                    yield return dict[type];
-                }
-            }
-        }
-
         private DbMigrator CreateDbMigrator(IDatabaseConfig config)
         {
             if (_migrationsConfiguration == null)
@@ -328,7 +291,7 @@ namespace Moryx.Model.Configuration
         /// </summary>
         private DbMigrationsConfiguration CreateDbMigrationsConfiguration()
         {
-            var configuration = _contextType.Assembly.DefinedTypes
+            var configuration = ContextType.Assembly.DefinedTypes
                 .FirstOrDefault(t => typeof(DbMigrationsConfiguration).IsAssignableFrom(t));
 
             if (configuration == null)

--- a/src/Moryx.Model/Configuration/NullModelConfigurator.cs
+++ b/src/Moryx.Model/Configuration/NullModelConfigurator.cs
@@ -18,12 +18,15 @@ namespace Moryx.Model.Configuration
         public IDatabaseConfig Config => null;
 
         /// <inheritdoc />
+        public Type ContextType { get; private set; }
+
+        /// <inheritdoc />
         public string TargetModel => string.Empty;
 
         /// <inheritdoc />
         public void Initialize(Type contextType, IConfigManager configManager, IModuleLogger logger)
         {
-
+            ContextType = contextType;
         }
 
         /// <inheritdoc />

--- a/src/Moryx.Model/DbContextManager.cs
+++ b/src/Moryx.Model/DbContextManager.cs
@@ -32,10 +32,7 @@ namespace Moryx.Model
 
         string ILoggingHost.Name => nameof(DbContextManager);
         private ModelWrapper[] _knownModels;
-
-        /// <inheritdoc />
-        public IReadOnlyCollection<IModelConfigurator> Configurators => _knownModels.Select(km => km.Configurator).ToList();
-
+        
         /// <inheritdoc />
         public void Initialize()
         {
@@ -68,6 +65,19 @@ namespace Moryx.Model
                 var logger = Logger.GetChild(configuratorType.Name, configuratorType);
                 wrapper.Configurator.Initialize(wrapper.DbContextType, ConfigManager, logger);
             }
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyCollection<Type> Contexts => _knownModels.Select(km => km.DbContextType).ToArray();
+
+        /// <inheritdoc />
+        public IModelConfigurator GetConfigurator(Type contextType) => _knownModels.First(km => km.DbContextType == contextType).Configurator;
+
+        /// <inheritdoc />
+        public IModelSetupExecutor GetSetupExecutor(Type contextType)
+        {
+            var setupExecutorType = typeof(ModelSetupExecutor<>).MakeGenericType(contextType);
+            return (IModelSetupExecutor)Activator.CreateInstance(setupExecutorType, this);
         }
 
         /// <inheritdoc />

--- a/src/Moryx.Model/EntityIdListener.cs
+++ b/src/Moryx.Model/EntityIdListener.cs
@@ -25,7 +25,7 @@ namespace Moryx.Model
         /// </summary>
         public static void Listen(IEntity entity, IPersistentObject target)
         {
-            Listen(entity, new PersistenListener(target));
+            Listen(entity, new PersistentListener(target));
         }
 
         /// <summary>
@@ -79,11 +79,11 @@ namespace Moryx.Model
             }
         }
 
-        private class PersistenListener : EntityIdListener
+        private class PersistentListener : EntityIdListener
         {
             private readonly IPersistentObject _target;
 
-            public PersistenListener(IPersistentObject target)
+            public PersistentListener(IPersistentObject target)
             {
                 _target = target;
             }

--- a/src/Moryx.Model/Extensions/DbContextExtensions.cs
+++ b/src/Moryx.Model/Extensions/DbContextExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System;
 using System.Data.Entity;
 
 namespace Moryx.Model

--- a/src/Moryx.Model/IDbContextManager.cs
+++ b/src/Moryx.Model/IDbContextManager.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Collections.Generic;
 using System.Data.Entity;
 using Moryx.Model.Configuration;
@@ -13,9 +14,19 @@ namespace Moryx.Model
     public interface IDbContextManager
     {
         /// <summary>
-        /// Per database context model configurator
+        /// Found DbContext types
         /// </summary>
-        IReadOnlyCollection<IModelConfigurator> Configurators { get; }
+        IReadOnlyCollection<Type> Contexts { get; }
+
+        /// <summary>
+        /// Get configurator for the given context type
+        /// </summary>
+        IModelConfigurator GetConfigurator(Type contextType);
+        
+        /// <summary>
+        /// Get setup executor for a model
+        /// </summary>
+        IModelSetupExecutor GetSetupExecutor(Type contextType);
 
         /// <summary>
         /// Creates a database context with the default configuration

--- a/src/Moryx.Model/IDbContextManager.cs
+++ b/src/Moryx.Model/IDbContextManager.cs
@@ -8,21 +8,44 @@ using Moryx.Model.Configuration;
 namespace Moryx.Model
 {
     /// <summary>
-    /// Global context management
+    /// Global component for handling database contexts
     /// </summary>
     public interface IDbContextManager
     {
+        /// <summary>
+        /// Per database context model configurator
+        /// </summary>
         IReadOnlyCollection<IModelConfigurator> Configurators { get; }
 
+        /// <summary>
+        /// Creates a database context with the default configuration
+        /// </summary>
+        /// <typeparam name="TContext">Database context type</typeparam>
+        /// <returns>Preconfigured instance of the given DbContext</returns>
         TContext Create<TContext>()
             where TContext : DbContext;
 
+        /// <summary>
+        /// Creates a database context with the given configuration
+        /// </summary>
+        /// <typeparam name="TContext">Database context type</typeparam>
+        /// <returns>Preconfigured instance of the given DbContext</returns>
         TContext Create<TContext>(IDatabaseConfig config)
             where TContext : DbContext;
 
+        /// <summary>
+        /// Creates a database context with the default configuration and custom initial context model
+        /// </summary>
+        /// <typeparam name="TContext">Database context type</typeparam>
+        /// <returns>Preconfigured instance of the given DbContext</returns>
         TContext Create<TContext>(ContextMode contextMode)
             where TContext : DbContext;
 
+        /// <summary>
+        /// Creates a database context with the given configuration and custom initial context model
+        /// </summary>
+        /// <typeparam name="TContext">Database context type</typeparam>
+        /// <returns>Preconfigured instance of the given DbContext</returns>
         TContext Create<TContext>(IDatabaseConfig config, ContextMode contextMode)
             where TContext : DbContext;
     }

--- a/src/Moryx.Model/IModelConfigurator.cs
+++ b/src/Moryx.Model/IModelConfigurator.cs
@@ -47,6 +47,11 @@ namespace Moryx.Model
         IDatabaseConfig Config { get; }
 
         /// <summary>
+        /// Type of the context
+        /// </summary>
+        Type ContextType { get; }
+
+        /// <summary>
         /// Target model name
         /// </summary>
         string TargetModel { get; }
@@ -145,19 +150,5 @@ namespace Moryx.Model
         /// <param name="config">Config to use</param>
         /// <param name="filePath">Filepath of dump</param>
         void RestoreDatabase(IDatabaseConfig config, string filePath);
-
-        /// <summary>
-        /// Get all setups for this model
-        /// </summary>
-        /// <returns></returns>
-        IEnumerable<IModelSetup> GetAllSetups();
-
-        /// <summary>
-        /// Execute setup for this config
-        /// </summary>
-        /// <param name="config">Config</param>
-        /// <param name="setup">Setup</param>
-        /// <param name="setupData"></param>
-        void Execute(IDatabaseConfig config, IModelSetup setup, string setupData);
     }
 }

--- a/src/Moryx.Model/IModelConfigurator.cs
+++ b/src/Moryx.Model/IModelConfigurator.cs
@@ -47,16 +47,6 @@ namespace Moryx.Model
         IDatabaseConfig Config { get; }
 
         /// <summary>
-        /// Type of the context
-        /// </summary>
-        Type ContextType { get; }
-
-        /// <summary>
-        /// Target model name
-        /// </summary>
-        string TargetModel { get; }
-
-        /// <summary>
         /// Initializes the model configurator
         /// </summary>
         void Initialize(Type contextType, IConfigManager configManager, IModuleLogger logger);

--- a/src/Moryx.Model/IModelSetup.cs
+++ b/src/Moryx.Model/IModelSetup.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
-using System.Data.Entity;
+using Moryx.Model.Repositories;
 
 namespace Moryx.Model
 {
@@ -33,48 +33,8 @@ namespace Moryx.Model
         /// <summary>
         /// Execute setup in this context
         /// </summary>
-        /// <param name="dbContext">Context for db access</param>
+        /// <param name="openContext">Context for db access</param>
         /// <param name="setupData">Any data for the setup, excel or sql etc</param>
-        void Execute(DbContext dbContext, string setupData);
-    }
-
-    /// <summary>
-    /// Setup to initialize a database
-    /// </summary>
-    public interface IModelSetup<in TContext> : IModelSetup where TContext : DbContext
-    {
-        /// <summary>
-        /// Execute setup in this context
-        /// </summary>
-        /// <param name="dbContext">Context for db access</param>
-        /// <param name="setupData">Any data for the setup, excel or sql etc</param>
-        void Execute(TContext dbContext, string setupData);
-    }
-
-    /// <summary>
-    /// Base class for model setups
-    /// </summary>
-    public abstract class ModelSetupBase<TContext> : IModelSetup<TContext> where TContext : DbContext
-    {
-        /// <inheritdoc />
-        public abstract int SortOrder { get; }
-
-        /// <inheritdoc />
-        public abstract string Name { get; }
-
-        /// <inheritdoc />
-        public abstract string Description { get; }
-
-        /// <inheritdoc />
-        public abstract string SupportedFileRegex { get; }
-
-        /// <inheritdoc />
-        public void Execute(DbContext dbContext, string setupData)
-        {
-            Execute((TContext) dbContext, setupData);
-        }
-
-        /// <inheritdoc />
-        public abstract void Execute(TContext dbContext, string setupData);
+        void Execute(IUnitOfWork openContext, string setupData);
     }
 }

--- a/src/Moryx.Model/IModelSetupExecutor.cs
+++ b/src/Moryx.Model/IModelSetupExecutor.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Moryx.Model.Configuration;
+
+namespace Moryx.Model
+{
+    /// <summary>
+    /// Handles and executes model setups for a certain database context
+    /// </summary>
+    public interface IModelSetupExecutor
+    {
+        /// <summary>
+        /// Returns all possible setups for the given DbContext
+        /// </summary>
+        IReadOnlyList<IModelSetup> GetAllSetups();
+
+        /// <summary>
+        /// Executes the given setup
+        /// </summary>
+        void Execute(IDatabaseConfig config, IModelSetup setup, string setupData);
+    }
+}

--- a/src/Moryx.Model/IModelSetupExecutor.cs
+++ b/src/Moryx.Model/IModelSetupExecutor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
 using System.Collections.Generic;
 using Moryx.Model.Configuration;
 

--- a/src/Moryx.Model/ModelSetupExecutor.cs
+++ b/src/Moryx.Model/ModelSetupExecutor.cs
@@ -12,7 +12,7 @@ using Moryx.Tools;
 namespace Moryx.Model
 {
     /// <inheritdoc />
-    public class ModelSetupExecutor<TContext> : IModelSetupExecutor
+    internal class ModelSetupExecutor<TContext> : IModelSetupExecutor
         where TContext : DbContext
     {
         private readonly IDbContextManager _dbContextManager;

--- a/src/Moryx.Model/ModelSetupExecutor.cs
+++ b/src/Moryx.Model/ModelSetupExecutor.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using Moryx.Model.Configuration;
+using Moryx.Model.Repositories;
+using Moryx.Tools;
+
+namespace Moryx.Model
+{
+    /// <inheritdoc />
+    public class ModelSetupExecutor<TContext> : IModelSetupExecutor
+        where TContext : DbContext
+    {
+        private readonly IDbContextManager _dbContextManager;
+        private readonly IModelSetup[] _setups;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ModelSetupExecutor{TContext}"/>
+        /// </summary>
+        /// <param name="dbContextManager"></param>
+        public ModelSetupExecutor(IDbContextManager dbContextManager)
+        {
+            _dbContextManager = dbContextManager;
+
+            // Load ModelSetups TODO: Load internals
+            _setups = ReflectionTool.GetPublicClasses<IModelSetup>(delegate (Type type)
+            {
+                // Try to read context from attribute
+                var setupAttr = type.GetCustomAttribute<ModelSetupAttribute>();
+                return setupAttr != null && setupAttr.TargetContext == typeof(TContext);
+            }).Select(s => (IModelSetup)Activator.CreateInstance((Type) s)).ToArray();
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<IModelSetup> GetAllSetups() => _setups;
+
+        /// <inheritdoc />
+        public void Execute(IDatabaseConfig config, IModelSetup setup, string setupData)
+        {
+            var unitOfWorkFactory = new UnitOfWorkFactory<TContext>(_dbContextManager);
+            using (var uow = unitOfWorkFactory.Create(config))
+                setup.Execute(uow, setupData);
+        }
+    }
+}

--- a/src/Moryx.Model/ModelSetupExecutor.cs
+++ b/src/Moryx.Model/ModelSetupExecutor.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2020, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
 using System;
 using System.Collections.Generic;
 using System.Data.Entity;

--- a/src/Moryx.Model/Moryx.Model.csproj
+++ b/src/Moryx.Model/Moryx.Model.csproj
@@ -77,6 +77,8 @@
     <Compile Include="IModelSetup.cs" />
     <Compile Include="DbContextManager.cs" />
     <Compile Include="Configuration\ModelConfiguratorBase.cs" />
+    <Compile Include="IModelSetupExecutor.cs" />
+    <Compile Include="ModelSetupExecutor.cs" />
     <Compile Include="Repositories\IUnitOfWorkFactory.cs" />
     <Compile Include="ModificationTrackedEntityBase.cs" />
     <Compile Include="MoryxDbContext.cs" />

--- a/src/Moryx.Model/MoryxDbContext.cs
+++ b/src/Moryx.Model/MoryxDbContext.cs
@@ -20,11 +20,6 @@ namespace Moryx.Model
         private static readonly MethodInfo DbInitializerMethod;
 
         /// <summary>
-        /// Indicator if modification tracking should be done automatically
-        /// </summary>
-        public bool EnableModificationTracking { get; set; } = true;
-
-        /// <summary>
         /// Static constructor to load the database initializer method
         /// </summary>
         static MoryxDbContext()
@@ -154,7 +149,7 @@ namespace Moryx.Model
         /// </summary>
         private void SetNullDatabaseInitializer()
         {
-            // Because of the limited entity framdework API, we have to call the Database initializer by reflection
+            // Because of the limited entity framework API, we have to call the Database initializer by reflection
             // Database.SetInitializer(new NullDatabaseInitializer<CustomContext>());
             var contextType = GetType();
             var initializerMethod = DbInitializerMethod.MakeGenericMethod(contextType);

--- a/src/Moryx.Runtime.DbUpdate/DbUpdateRunMode.cs
+++ b/src/Moryx.Runtime.DbUpdate/DbUpdateRunMode.cs
@@ -22,19 +22,20 @@ namespace Moryx.Runtime.DbUpdate
         public override RuntimeErrorCode Run()
         {
             Console.WriteLine("Updating databases...");
-            foreach (var configurator in DbContextManager.Configurators)
+            foreach (var contextType in DbContextManager.Contexts)
             {
+                var configurator = DbContextManager.GetConfigurator(contextType);
                 try
                 {
                     var summary = configurator.MigrateDatabase(configurator.Config);
                     if (!summary.WasUpdated)
                     {
-                        Console.WriteLine("No updates for {0}", configurator.TargetModel);
+                        Console.WriteLine("No updates for {0}", contextType.FullName);
                         continue;
                     }
 
                     // Display update summary
-                    Console.WriteLine("Update summary for {0}:", configurator.TargetModel);
+                    Console.WriteLine("Update summary for {0}:", contextType.FullName);
                     foreach (var update in summary.ExecutedUpdates)
                     {
                         Console.WriteLine("{0}->{1}: {2}", update.From, update.To, update.Description);
@@ -42,7 +43,7 @@ namespace Moryx.Runtime.DbUpdate
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine("Update for {0} failed with exception:\n  {1}", configurator.TargetModel, ex.Message);
+                    Console.WriteLine("Update for {0} failed with exception:\n  {1}", contextType.FullName, ex.Message);
                 }
             }
             Console.WriteLine("Update complete");

--- a/src/Moryx.Runtime.Maintenance/Plugins/Databases/Wcf/DatabaseMaintenance.cs
+++ b/src/Moryx.Runtime.Maintenance/Plugins/Databases/Wcf/DatabaseMaintenance.cs
@@ -11,8 +11,6 @@ using Moryx.Container;
 using Moryx.Logging;
 using Moryx.Model;
 using Moryx.Model.Configuration;
-using Moryx.Runtime.Modules;
-using Moryx.Threading;
 
 namespace Moryx.Runtime.Maintenance.Plugins.Databases
 {

--- a/src/Moryx.Runtime.Maintenance/Plugins/Databases/Wcf/DatabaseMaintenance.cs
+++ b/src/Moryx.Runtime.Maintenance/Plugins/Databases/Wcf/DatabaseMaintenance.cs
@@ -38,20 +38,14 @@ namespace Moryx.Runtime.Maintenance.Plugins.Databases
 
         #endregion
 
-        #region Fields and Properties
-
-        private IEnumerable<IModelConfigurator> ModelConfigurators => DbContextManager.Configurators;
-
-        #endregion
-
         public DataModel[] GetAll()
         {
-            return ModelConfigurators.Select(Convert).ToArray();
+            return DbContextManager.Contexts.Select(Convert).ToArray();
         }
 
         public DataModel GetModel(string targetModel)
         {
-            return Convert(ModelConfigurators.FirstOrDefault(m => m.TargetModel == targetModel));
+            return Convert(DbContextManager.Contexts.FirstOrDefault(context => TargetModelName(context) == targetModel));
         }
 
         public void SetAllConfigs(DatabaseConfigModel config)
@@ -192,14 +186,15 @@ namespace Moryx.Runtime.Maintenance.Plugins.Databases
 
         public InvocationResponse ExecuteSetup(string targetModel, ExecuteSetupRequest request)
         {
-            var targetConfigurator = GetTargetConfigurator(targetModel);
+            var contextType = DbContextManager.Contexts.First(c => TargetModelName(c) == targetModel);
+            var targetConfigurator = DbContextManager.GetConfigurator(contextType);
             if (targetConfigurator == null)
                 return new InvocationResponse("No configurator found");
 
             // Update config copy from model
             var config = UpdateConfigFromModel(targetConfigurator.Config, request.Config);
 
-            var setupExecutor = CreateModelSetupExecutor(targetConfigurator);
+            var setupExecutor = DbContextManager.GetSetupExecutor(contextType);
 
             var targetSetup = setupExecutor.GetAllSetups().FirstOrDefault(s => s.GetType().FullName == request.Setup.Fullname);
             if (targetSetup == null)
@@ -222,12 +217,6 @@ namespace Moryx.Runtime.Maintenance.Plugins.Databases
             }
         }
 
-        private IModelSetupExecutor CreateModelSetupExecutor(IModelConfigurator targetConfigurator)
-        {
-            var setupExecutorType = typeof(ModelSetupExecutor<>).MakeGenericType(targetConfigurator.ContextType);
-            return (IModelSetupExecutor)Activator.CreateInstance(setupExecutorType, DbContextManager);
-        }
-
         private SetupModel ConvertSetup(IModelSetup setup)
         {
             var model = new SetupModel
@@ -243,12 +232,13 @@ namespace Moryx.Runtime.Maintenance.Plugins.Databases
 
         private IModelConfigurator GetTargetConfigurator(string model)
         {
-            var match = ModelConfigurators.FirstOrDefault(configurator => configurator.TargetModel == model);
-            return match;
+            var context = DbContextManager.Contexts.First(c => TargetModelName(c) == model);
+            return DbContextManager.GetConfigurator(context);
         }
 
-        private DataModel Convert(IModelConfigurator configurator)
+        private DataModel Convert(Type contextType)
         {
+            var configurator = DbContextManager.GetConfigurator(contextType);
             if (configurator?.Config == null)
             {
                 return null;
@@ -257,7 +247,7 @@ namespace Moryx.Runtime.Maintenance.Plugins.Databases
             var dbConfig = configurator.Config;
             var model = new DataModel
             {
-                TargetModel = configurator.TargetModel,
+                TargetModel = TargetModelName(contextType),
                 Config = new DatabaseConfigModel
                 {
                     Server = dbConfig.Host,
@@ -266,17 +256,17 @@ namespace Moryx.Runtime.Maintenance.Plugins.Databases
                     User = dbConfig.Username,
                     Password = dbConfig.Password
                 },
-                Setups = GetAllSetups(configurator),
-                Backups = GetAllBackups(configurator),
+                Setups = GetAllSetups(contextType),
+                Backups = GetAllBackups(contextType),
                 AvailableMigrations = GetAvailableUpdates(dbConfig, configurator),
                 AppliedMigrations = GetInstalledUpdates(dbConfig, configurator)
             };
             return model;
         }
 
-        private SetupModel[] GetAllSetups(IModelConfigurator configurator)
+        private SetupModel[] GetAllSetups(Type contextType)
         {
-            var setupExecutor = CreateModelSetupExecutor(configurator);
+            var setupExecutor = DbContextManager.GetSetupExecutor(contextType);
             var allSetups = setupExecutor.GetAllSetups();
             var setups = allSetups.Where(setup => string.IsNullOrEmpty(setup.SupportedFileRegex))
                                   .Select(ConvertSetup).OrderBy(setup => setup.SortOrder).ToList();
@@ -295,9 +285,9 @@ namespace Moryx.Runtime.Maintenance.Plugins.Databases
             return setups.OrderBy(setup => setup.SortOrder).ToArray();
         }
 
-        private BackupModel[] GetAllBackups(IModelConfigurator configurator)
+        private BackupModel[] GetAllBackups(Type contextType)
         {
-            var targetModel = configurator.TargetModel;
+            var targetModel = TargetModelName(contextType);
 
             if (!Directory.Exists(Config.SetupDataDir))
             {
@@ -347,19 +337,22 @@ namespace Moryx.Runtime.Maintenance.Plugins.Databases
             return dbConfig;
         }
 
+        private static string TargetModelName(Type contextType) => contextType.FullName;
+
         private string BulkOperation(Action<IModelConfigurator> operation, string operationName)
         {
             var result = string.Empty;
-            foreach (var configurator in ModelConfigurators)
+            foreach (var contextType in DbContextManager.Contexts)
             {
+                var configurator = DbContextManager.GetConfigurator(contextType);
                 try
                 {
                     operation(configurator);
                 }
                 catch (Exception ex)
                 {
-                    Logger.LogException(LogLevel.Warning, ex, "{0} of {1} failed!", operationName, configurator.TargetModel);
-                    result += $"{operationName} of {configurator.TargetModel} failed!\n";
+                    Logger.LogException(LogLevel.Warning, ex, "{0} of {1} failed!", operationName, TargetModelName(contextType));
+                    result += $"{operationName} of {TargetModelName(contextType)} failed!\n";
                 }
             }
             return result;

--- a/src/Moryx.Runtime.SmokeTest/SmokeTest.cs
+++ b/src/Moryx.Runtime.SmokeTest/SmokeTest.cs
@@ -89,20 +89,20 @@ namespace Moryx.Runtime.SmokeTest
             }
 
             // Load model configurators
-            var modelConfigurators = DbContextManager.Configurators;
-
+            var contexts = DbContextManager.Contexts;
             // Create all databases
-            foreach (var modelConfigurator in modelConfigurators)
+            foreach (var contextType in contexts)
             {
+                var configurator = DbContextManager.GetConfigurator(contextType);
                 try
                 {
                     // Add database config prefix
-                    modelConfigurator.Config.Database = $"smokeTest-{modelConfigurator.TargetModel}";
-                    modelConfigurator.CreateDatabase(modelConfigurator.Config);
+                    configurator.Config.Database = $"smokeTest-{contextType.FullName}";
+                    configurator.CreateDatabase(configurator.Config);
                 }
                 catch
                 {
-                    Console.WriteLine("Failed to create data model {0}", modelConfigurator.TargetModel);
+                    Console.WriteLine("Failed to create data model {0}", contextType.FullName);
                 }
             }
 
@@ -118,15 +118,16 @@ namespace Moryx.Runtime.SmokeTest
             var result = RunTests();
 
             // Delete all databases
-            foreach (var modelConfigurator in modelConfigurators)
+            foreach (var context in contexts)
             {
+                var modelConfigurator = DbContextManager.GetConfigurator(context);
                 try
                 {
                     modelConfigurator.DeleteDatabase(modelConfigurator.Config);
                 }
                 catch
                 {
-                    Console.WriteLine("Failed to delete data model {0}", modelConfigurator.TargetModel);
+                    Console.WriteLine("Failed to delete data model {0}", context.FullName);
                 }
             }
 


### PR DESCRIPTION
Additionally to #4 - ModelSetups should be executed with IUnitOfWork again. The UnitOfWork also provides the DbContext if necessary. 