### PR TITLE
Add option for full name to possible types

### DIFF
--- a/src/Moryx/Serialization/PossibleValues/PossibleTypesAttribute.cs
+++ b/src/Moryx/Serialization/PossibleValues/PossibleTypesAttribute.cs
@@ -17,6 +17,11 @@ namespace Moryx.Serialization
         private readonly Type[] _types;
 
         /// <summary>
+        /// Flag if types should be returned including namespace
+        /// </summary>
+        public bool UseFullname { get; set; }
+
+        /// <summary>
         /// Creates an new instance of <see cref="PossibleTypesAttribute"/>
         /// Searches for all public implementations of the given base types.
         /// </summary>
@@ -35,15 +40,15 @@ namespace Moryx.Serialization
         }
 
         /// <inheritdoc />
-        public override IEnumerable<string> GetValues(IContainer container)
-        {
-            return _types.Select(t => t.Name);
-        }
-
-        /// <inheritdoc />
         public override bool OverridesConversion => false;
 
         /// <inheritdoc />
         public override bool UpdateFromPredecessor => false;
+
+        /// <inheritdoc />
+        public override IEnumerable<string> GetValues(IContainer container)
+        {
+            return _types.Select(t => UseFullname ? t.FullName : t.Name);
+        }
     }
 }

--- a/src/Tests/Moryx.Tests/Serialization/PossibleValues/PossibleValuesAttributeTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/PossibleValues/PossibleValuesAttributeTests.cs
@@ -24,11 +24,13 @@ namespace Moryx.Tests
         {
             // Arrange
             var attrWithBase = new PossibleTypesAttribute(typeof(SomeBase));
-            var attrWithArray = new PossibleTypesAttribute(new[] {typeof(SomeImpl) });
+            var attrWithArray = new PossibleTypesAttribute(new[] { typeof(SomeImpl) });
+            var attrWithFull = new PossibleTypesAttribute(typeof(SomeBase)) { UseFullname = true };
 
             // Act
             var valuesFromBase = attrWithBase.GetValues(null).ToArray();
             var valuesFromArray = attrWithArray.GetValues(null).ToArray();
+            var valuesWithFull = attrWithFull.GetValues(null).ToArray();
 
             // Assert
             // Check values from base type
@@ -39,6 +41,11 @@ namespace Moryx.Tests
             // Check values from array types
             Assert.AreEqual(1, valuesFromArray.Length);
             Assert.AreEqual(nameof(SomeImpl), valuesFromArray[0]);
+
+            // Check values from base type with full name
+            Assert.AreEqual(2, valuesWithFull.Length);
+            Assert.AreEqual(typeof(SomeBase).FullName, valuesWithFull[0]);
+            Assert.AreEqual(typeof(SomeImpl).FullName, valuesWithFull[1]);
         }
 
         [Test(Description = "Uses the " + nameof(StateMachineKeysAttribute) + " to read possible state keys from the given state machine type.")]


### PR DESCRIPTION
I had a scenario where I needed the full name of the type. Instead of creating an almost identical attribute, I extended possible types instead.