### PR TITLE
Fix dictionary detection in EntryConvert

### DIFF
--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -33,7 +33,11 @@ namespace Moryx.Serialization
         /// </summary>
         public static bool IsDictionary(Type collectionType)
         {
-            return collectionType.IsGenericType && typeof(IDictionary<,>).IsAssignableFrom(collectionType.GetGenericTypeDefinition());
+            if (typeof(IDictionary).IsAssignableFrom(collectionType))
+                return true;
+
+            return collectionType.IsGenericType
+                   && collectionType.GetGenericTypeDefinition() == typeof(IDictionary<,>);
         }
 
         /// <summary>


### PR DESCRIPTION
While the current code looked fine, it actually returned false when checking against a real dictionary. Just checking against `IDictionary` works for `Dictionary<,>` but not for the interface `IDictionary<,>`.

It will not work for interfaces derived from `IDictionary<,>`, but do we really have that requirement?

Closes #35.