### PR TITLE
Fix spelling and include RangeAttribute in validation

### DIFF
--- a/src/Moryx/Serialization/DefaultSerialization.cs
+++ b/src/Moryx/Serialization/DefaultSerialization.cs
@@ -93,17 +93,25 @@ namespace Moryx.Serialization
             // Iterate over attributes reading all validation rules
             foreach (var attribute in validationAttributes)
             {
-                if (attribute is MinLengthAttribute)
-                    validation.MinLenght = ((MinLengthAttribute)attribute).Length;
-                else if (attribute is MaxLengthAttribute)
-                    validation.MaxLenght = ((MaxLengthAttribute)attribute).Length;
-                else if (attribute is RegularExpressionAttribute)
-                    validation.Regex = ((RegularExpressionAttribute)attribute).Pattern;
-                else if (attribute is StringLengthAttribute)
+                if (attribute is MinLengthAttribute minAttribute)
                 {
-                    var strLength = (StringLengthAttribute)attribute;
-                    validation.MinLenght = strLength.MinimumLength;
-                    validation.MaxLenght = strLength.MaximumLength;
+                    validation.Minimum = minAttribute.Length;
+                }
+                else if (attribute is MaxLengthAttribute maxAttribute)
+                {
+                    validation.Maximum = maxAttribute.Length;
+                }
+                else if (attribute is RangeAttribute rangeAttribute)
+                {
+                    validation.Minimum = Convert.ToDouble(rangeAttribute.Minimum);
+                    validation.Maximum = Convert.ToDouble(rangeAttribute.Maximum);
+                }
+                else if (attribute is RegularExpressionAttribute regexAttribute)
+                    validation.Regex = regexAttribute.Pattern;
+                else if (attribute is StringLengthAttribute strLength)
+                {
+                    validation.Minimum = strLength.MinimumLength;
+                    validation.Maximum = strLength.MaximumLength;
                 }
                 else if (attribute is RequiredAttribute)
                     validation.IsRequired = true;

--- a/src/Moryx/Serialization/EntryConvert/EntryValidation.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryValidation.cs
@@ -13,16 +13,16 @@ namespace Moryx.Serialization
     public class EntryValidation : ICloneable
     {
         /// <summary>
-        /// Minimal lenght of strings or other types
+        /// Minimum value or minimal length of strings
         /// </summary>
         [DataMember]
-        public int MinLenght { get; set; }
+        public double Minimum { get; set; }
 
         /// <summary>
-        /// Maximal lenght of strings or other types
+        /// Maximum value or maximal length of strings
         /// </summary>
         [DataMember]
-        public int MaxLenght { get; set; }
+        public double Maximum { get; set; }
 
         /// <summary>
         /// Regex pattern for this entry
@@ -50,8 +50,8 @@ namespace Moryx.Serialization
             // All value types can be simply copied
             var copy = new EntryValidation
             {
-                MinLenght = MinLenght, 
-                MaxLenght = MaxLenght, 
+                Minimum = Minimum, 
+                Maximum = Maximum, 
                 Regex = Regex, 
                 IsRequired = IsRequired
             };


### PR DESCRIPTION
I received feedback about a spelling error in EntryValidation and the idea, to make the value more flexible and also include range validation values.