### PR TITLE
Symbol packages (snupkg) must be published by v3 nuget api

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,6 +16,7 @@ env:
   MORYX_BUILDNUMBER: ${{github.run_number}}
   MORYX_NUGET_APIKEY: ${{secrets.MYGET_TOKEN}}
   MORYX_PACKAGE_TARGET: "https://www.myget.org/F/moryx/api/v2/package"
+  MORYX_PACKAGE_TARGET_V3: "https://www.myget.org/F/moryx/api/v3/index.json"
 
 jobs:
   Build:

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,11 +3,6 @@
 
   <Import Project=".build\Common.props" Condition="'$(CreatePackage)' == 'true'" />
 
-  <!-- Properties for all projects if CreatePackage=true -->
-  <PropertyGroup Condition="'$(CreatePackage)' == 'true'">
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-
   <!-- Package refereces for all projects if CreatePackage=true -->
   <ItemGroup Condition="'$(CreatePackage)' == 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/Directory.build.props
+++ b/Directory.build.props
@@ -7,8 +7,6 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
 
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/PHOENIXCONTACT/MORYX-Platform</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
 
     <IncludeSymbols>true</IncludeSymbols>

--- a/src/Moryx.Communication.Serial/Moryx.Communication.Serial.csproj
+++ b/src/Moryx.Communication.Serial/Moryx.Communication.Serial.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Library for serial port communication.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Container/Moryx.Container.csproj
+++ b/src/Moryx.Container/Moryx.Container.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Handling of container structure.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Model.InMemory/Moryx.Model.InMemory.csproj
+++ b/src/Moryx.Model.InMemory/Moryx.Model.InMemory.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>InMemory extension to Moryx.Model.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Model.PostgreSQL/Moryx.Model.PostgreSQL.csproj
+++ b/src/Moryx.Model.PostgreSQL/Moryx.Model.PostgreSQL.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net45;net461</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>EntityFramework DataModel based on Npgsql.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Model/Moryx.Model.csproj
+++ b/src/Moryx.Model/Moryx.Model.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Extended model functionality.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Runtime.DbUpdate/Moryx.Runtime.DbUpdate.csproj
+++ b/src/Moryx.Runtime.DbUpdate/Moryx.Runtime.DbUpdate.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Runtime RunMode for executing database migrations.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Runtime.Kernel/Moryx.Runtime.Kernel.csproj
+++ b/src/Moryx.Runtime.Kernel/Moryx.Runtime.Kernel.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Main kernel abstraction for the runtime environment</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Runtime.Maintenance/Moryx.Runtime.Maintenance.csproj
+++ b/src/Moryx.Runtime.Maintenance/Moryx.Runtime.Maintenance.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Core module to maintain the application. It provides config and logging support by default.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Runtime.SmokeTest/Moryx.Runtime.SmokeTest.csproj
+++ b/src/Moryx.Runtime.SmokeTest/Moryx.Runtime.SmokeTest.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Runtime RunMode for executing smoke tests.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Runtime.Wcf/Moryx.Runtime.Wcf.csproj
+++ b/src/Moryx.Runtime.Wcf/Moryx.Runtime.Wcf.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Extensions for the Moryx.Runtime for hosting wcf services.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Runtime.WinService/Moryx.Runtime.WinService.csproj
+++ b/src/Moryx.Runtime.WinService/Moryx.Runtime.WinService.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Provides runtime mode for running as Windows Service.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Runtime/Moryx.Runtime.csproj
+++ b/src/Moryx.Runtime/Moryx.Runtime.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Contains core interfaces for the runtime environment.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.TestTools.SystemTest/Moryx.TestTools.SystemTest.csproj
+++ b/src/Moryx.TestTools.SystemTest/Moryx.TestTools.SystemTest.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Library with helper classes for SystemTests.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.TestTools.UnitTest/Moryx.TestTools.UnitTest.csproj
+++ b/src/Moryx.TestTools.UnitTest/Moryx.TestTools.UnitTest.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Library with helper classes for UnitTests.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx.Tools.Wcf/Moryx.Tools.Wcf.csproj
+++ b/src/Moryx.Tools.Wcf/Moryx.Tools.Wcf.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45;net461</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Wcf integation in Platform.</Description>
     <CreatePackage>true</CreatePackage>
   </PropertyGroup>

--- a/src/Moryx/Moryx.csproj
+++ b/src/Moryx/Moryx.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45;net461</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>Root namespace of the MORYX ecosystem</Description>
     <CreatePackage>true</CreatePackage>


### PR DESCRIPTION
Here are some hints about the change:

- snupkg packages can only be published by nuget v3 api
- nuget packages can only be published by nuget v2 api on myget 

I added another environment variable for the v3 api to publish the snupkg's.

Another problem which is fixed (work around): I don't know why it is not possible to set the `GenerateDocumentationFile` property within the `Directory.Build.targets`. It is possible within the `Directory.Build.props` but I must use the condition to add this property only if `CreatePackage = true`

````xml
<PropertyGroup Condition="'$(CreatePackage)' == 'true'">
````

I rolled back the change of #68 and moved the `GenerateDocumentationFile` back to the project file.

P.S.: I cannot say if the change regarding the v3 api really works fine, this can only be tested if this is merged.