### PR TITLE
Replace equatable with static compare

### DIFF
--- a/src/Moryx/Serialization/EntryConvert/Entry.cs
+++ b/src/Moryx/Serialization/EntryConvert/Entry.cs
@@ -12,7 +12,7 @@ namespace Moryx.Serialization
     /// Model class representing a single property of a config class
     /// </summary>
     [DataContract]
-    public class Entry : ICloneable, IEquatable<Entry>
+    public class Entry : ICloneable
     {
         /// <summary>
         /// Identifier used for entry objects that function as prototypes
@@ -165,73 +165,35 @@ namespace Moryx.Serialization
         }
 
         /// <summary>
-        /// Overload of the comparison operator mapped to the <see cref="Equals(Entry)"/> method
+        /// Compare two entries recursive to detect changes
         /// </summary>
-        public static bool operator ==(Entry left, Entry right)
+        public static bool ValuesEqual(Entry left, Entry right)
         {
-            if (ReferenceEquals(null, left))
-                return ReferenceEquals(right, null);
-
-            return left.Equals(right);
-        }
-
-        /// <summary>
-        /// Overload of the comparison operator mapped to the <see cref="Equals(Entry)"/> method
-        /// </summary>
-        public static bool operator !=(Entry left, Entry right)
-        {
-            return !(left == right);
-        }
-
-        /// <inheritdoc />
-        public bool Equals(Entry other)
-        {
-            if (other == null)
+            if (left == null || right == null)
                 return false;
 
-            if (ReferenceEquals(this, other))
+            if (ReferenceEquals(left, right))
                 return true;
 
-            if (Value.Current != other.Value.Current)
+            if (left.Value.Current != right.Value.Current)
                 return false;
 
-            if (SubEntries.Count != other.SubEntries.Count)
+            if (left.SubEntries.Count != right.SubEntries.Count)
                 return false;
 
-            foreach (var leftEntry in SubEntries)
+            foreach (var leftEntry in left.SubEntries)
             {
-                var rightEntry = other.SubEntries.FirstOrDefault(p => p.Identifier == leftEntry.Identifier);
+                var rightEntry = right.SubEntries.FirstOrDefault(p => p.Identifier == leftEntry.Identifier);
                 if (rightEntry == null)
                     return false;
 
-                if (!leftEntry.Equals(rightEntry))
+                if (!ValuesEqual(leftEntry, rightEntry))
                     return false;
             }
 
             return true;
         }
-
-        /// <inheritdoc />
-        public override bool Equals(object obj)
-        {
-            var entry = obj as Entry;
-            return entry != null && Equals(entry);
-        }
-
-        /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                // ReSharper disable NonReadonlyMemberInGetHashCode
-                // These values will not be modified
-                var hashCode = Identifier.GetHashCode();
-                hashCode = (hashCode * 397) ^ Value.Current.GetHashCode();
-                hashCode = (hashCode * 397) ^ SubEntries.GetHashCode();
-                return hashCode;
-            }
-        }
-
+        
         /// <inheritdoc />
         public override string ToString() =>
             $"{DisplayName}: {Value.Current}";

--- a/src/Tests/Moryx.Tests/Serialization/SerializationTests.cs
+++ b/src/Tests/Moryx.Tests/Serialization/SerializationTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Moryx.Serialization;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Moryx.Tests
@@ -613,7 +614,7 @@ namespace Moryx.Tests
             var clone = entry.Clone(true);
 
             // Act
-            var equals = entry.Equals(clone);
+            var equals = Entry.ValuesEqual(entry, clone);
 
             // Assert
             Assert.IsTrue(equals);
@@ -627,7 +628,7 @@ namespace Moryx.Tests
             var entry2 = CreateTestEntry();
 
             // Act
-            var equals = entry.Equals(entry2);
+            var equals = Entry.ValuesEqual(entry, entry2);
 
             // Assert
             Assert.IsTrue(equals);
@@ -643,7 +644,7 @@ namespace Moryx.Tests
             entry.Value.Current = "OtherValue";
 
             // Act
-            var equals = entry.Equals(entry2);
+            var equals = Entry.ValuesEqual(entry, entry2);
 
             // Assert
             Assert.IsFalse(equals);
@@ -695,22 +696,6 @@ namespace Moryx.Tests
 
             // Assert
             Assert.IsFalse(equals);
-        }
-
-        [Test]
-        public void EntryEqualsWithComparisonOperator()
-        {
-            // Arrange
-            var entry = CreateTestEntry();
-            var entry2 = CreateTestEntry();
-
-            // Act
-            var aEqualsB = entry == entry2;
-            var aNotEqualsB = entry != entry2;
-
-            // Assert
-            Assert.IsTrue(aEqualsB);
-            Assert.IsFalse(aNotEqualsB);
         }
 
         [Test(Description = "Encodes a MemoryStream")]


### PR DESCRIPTION
`IEquatable` on `Entry` caused reference loop exceptins in JSON, when a value was identical with its prototype. 

See: JamesNK/Newtonsoft.Json#2419

Because we can not expect Json.Net to change behavior, we drop `IEquatable` to avoid side effects.
