### PR TITLE
Add missing validation to prototypes

### DIFF
--- a/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
+++ b/src/Moryx/Serialization/EntryConvert/EntryConvert.cs
@@ -143,10 +143,12 @@ namespace Moryx.Serialization
             var possibleElementValues = IsCollection(memberType)
                 ? customSerialization.PossibleElementValues(memberType, customAttributeProvider)
                 : customSerialization.PossibleValues(memberType, customAttributeProvider);
+            var validation = customSerialization.CreateValidation(memberType, customAttributeProvider);
 
             foreach (var prototype in customSerialization.Prototypes(memberType, customAttributeProvider))
             {
                 var prototypeEntry = Prototype(prototype, customSerialization);
+                prototypeEntry.Validation = validation;
                 prototypeEntry.Value.Possible = possibleElementValues;
                 yield return prototypeEntry;
             }


### PR DESCRIPTION
@mmarkwort noticed that primitive prototypes do not have validation information.