### PR TITLE
Use s format specifier for crash log timestamp

### DIFF
--- a/src/Moryx/Tools/CrashHandler.cs
+++ b/src/Moryx/Tools/CrashHandler.cs
@@ -40,15 +40,15 @@ namespace Moryx.Tools
                 Environment.Exit(2);
             }
         }
-        
+
         /// <summary>
         /// Write an exception message to a file in the CrashLogs directory
         /// </summary>
         public static void WriteErrorToFile(string message)
         {
             var crashDir = Path.Combine(Directory.GetCurrentDirectory(), @"CrashLogs");
-            var fileName = $@"{crashDir}\CrashLog_{DateTime.Now:yy-MM-dd_hh-mm-ss}.txt";
-            
+            var fileName = $@"{crashDir}\CrashLog_{DateTime.Now:s}.txt";
+
             if (!Directory.Exists(crashDir))
                 Directory.CreateDirectory(crashDir);
 


### PR DESCRIPTION
The crashlog timestamp uses the 12h format without am/pm. We should treat it as bug and change it to the default "s" specifier:

````cs
//    s Format Specifier      de-DE Culture                      2008-10-01T17:04:32
//    s Format Specifier      en-US Culture                      2008-10-01T17:04:32
//    s Format Specifier      es-ES Culture                      2008-10-01T17:04:32
//    s Format Specifier      fr-FR Culture                      2008-10-01T17:04:32
````