### PR TITLE
Fix typos and xref links/missing quickstart in docs

### DIFF
--- a/docs/articles/Platform/DataModel/ModificationTracking.md
+++ b/docs/articles/Platform/DataModel/ModificationTracking.md
@@ -5,7 +5,7 @@ uid: Model.ModificationTracking
 
 ## Introduction
 
-Sometimes developers want to keep track about modifications of a row in their table. MORYX framework has a built in solution to keep track about creation, update and deletion time.
+Sometimes developers want to keep track about modifications of a row in their table. MORYX framework has a built-in solution to keep track about creation, update and deletion time.
 
 To make an entity trackable you just need to derive from [IModificationTrackedEntity](xref:Moryx.Model.IModificationTrackedEntity) or the corresponding base class [ModificationTrackedEntityBase](xref:Moryx.Model.ModificationTrackedEntityBase).
 
@@ -16,7 +16,7 @@ public class PersonEntity : ModificationTrackedEntityBase
 }
 ````
 
-The example above defines four aditional columns: Id (from `EntityBase`), Created, Updated and Deleted. The last three properties are introduced by the `ModificationTrackedEntityBase` and will be used in a special way by the framework and the database:
+The example above defines four additional columns: Id (from `EntityBase`), Created, Updated and Deleted. The last three properties are introduced by the `ModificationTrackedEntityBase` and will be used in a special way by the framework and the database:
 
 - `Created`: Indicates the time when the row was created
 - `Updated`: Shows when the row was updated
@@ -30,4 +30,4 @@ You do not need to treat modified trackable entities in another way. It will wor
 
 ## A last word
 
-If you are interessted how the modified trackable mechanism is implemented you'll find some deeper information in [Code First](xref:GettingsStarted.CodeFirst) article or the [EntityFramework Tutorial](https://www.entityframeworktutorial.net/faq/set-created-and-modified-date-in-efcore.aspx)
+If you are interested how the modified trackable mechanism is implemented you'll find some deeper information in [Code First](xref:GettingsStarted.CodeFirst) article or the [EntityFramework Tutorial](https://www.entityframeworktutorial.net/faq/set-created-and-modified-date-in-efcore.aspx)

--- a/docs/articles/Platform/DataModel/UnitOfWorkPattern.md
+++ b/docs/articles/Platform/DataModel/UnitOfWorkPattern.md
@@ -61,4 +61,4 @@ public void WriteSomethingToDB()
 
 As you can see you just need to write the most important things. You might wonder how the magic of runtime code generation in context to the repository works. If you want to know more have a look on the [RepositoryProxyBuilder](xref:Model.RepositoryProxyBuilder).
 
-For a complete example please read the [CodeFirst tutorial](xref:GettingsStarted.CodeFirst#Customizations to the migration process).
+For a complete example please read the [CodeFirst tutorial](xref:GettingStarted.CodeFirst#unitofwork-repository-pattern).

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -6,7 +6,7 @@ The Moryx Platform is our concept of the eco system in which we develop software
 
 ## 2. Getting Started
 
-If you are new to the `MoryxPlatform`, please follow the [Quickstart](xref:Quickstart) provided in the Tutorials section.
+If you are new to the `MoryxPlatform`, please follow the [Quickstart Guide](xref:QuickstartGuide) provided in the Tutorials section.
 
 ## 3. Use MoryxPlatform Packages
 

--- a/docs/tutorials/DataModel/CodeFirst.md
+++ b/docs/tutorials/DataModel/CodeFirst.md
@@ -1,5 +1,5 @@
 ---
-uid: GettingsStarted.CodeFirst
+uid: GettingStarted.CodeFirst
 ---
 # Code first
 
@@ -106,7 +106,7 @@ Is that necessary?
 That's pretty much better because the [EntityBase](xref:Moryx.Model.EntityBase) defines an extra property for the `Id`. 
 This `Id` is treated specially as self incrementing primary key. [ModificationTrackedEntityBase](xref:Moryx.Model.ModificationTrackedEntityBase) derives from the base. 
 It has three properties which are monitored by triggers (Created, Updated, Deleted). 
-These triggers are automatically applied to the entitiy. 
+These triggers are automatically applied to the entity. 
 You can find further information regarding Modification Tracking [here](../../articles/Platform/DataModel/ModificationTracking.md).
 
 ## Entity loading & change tracking behavior
@@ -279,7 +279,7 @@ The entity framework comes with three scripts to do database model migration:
 | `Add-Migration`     | This script is executed every time you want to create a new migration |
 | `Update-Database`   | This runs all database migrations found in the corresponding assembly. This step can also be called from code. |
 
-When EF guys are talking about the *CodeFirst Migrations* approach they mean exaclty these three scripts.
+When EF guys are talking about the *CodeFirst Migrations* approach they mean exactly these three scripts.
 
 ### Initial creation of migration configuration
 

--- a/docs/tutorials/DataModel/ModelSetups.md
+++ b/docs/tutorials/DataModel/ModelSetups.md
@@ -1,5 +1,5 @@
 ---
-uid: GettingsStarted.ModelSteups
+uid: GettingStarted.ModelSetups
 ---
 # Model Setups
 
@@ -39,7 +39,7 @@ First we have to take care of the properties required by the Runtime. They are n
 
 ### Hard coded entity creation
 
-When the setup gets executed, MORYX will create a `IUnitOfWork` and povides it within the `Execute` method. Here everything can be done for setting up the database:
+When the setup gets executed, MORYX will create a `IUnitOfWork` and provides it within the `Execute` method. Here everything can be done for setting up the database:
 
 ````cs
 public void Execute(IUnitOfWork openContext, string setupData)

--- a/docs/tutorials/QuickstartGuide.md
+++ b/docs/tutorials/QuickstartGuide.md
@@ -1,0 +1,7 @@
+---
+uid: QuickstartGuide
+---
+
+# Getting Started with MoryxPlatform
+
+.. TODO ..

--- a/docs/tutorials/toc.yml
+++ b/docs/tutorials/toc.yml
@@ -1,7 +1,7 @@
 - name: Getting Started
-  items: 
-  - name: Quickstart
-    href: Quickstart.md
+  items:
+  - name: Quickstart Guide
+    href: QuickstartGuide.md
 
   - name: ServerModule
     href: ServerModule/toc.yml


### PR DESCRIPTION
Fixes typos, some links and adds QuickstartGuide.md file to docs due to the fact that it was missing.