### PR TITLE
Parse and use configured IPAddress in tcp listener

### DIFF
--- a/src/Moryx/Communication/Sockets/Server/TcpListenerConnection.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpListenerConnection.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0
 
 using System;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Moryx.Container;
@@ -57,6 +58,11 @@ namespace Moryx.Communication.Sockets
         internal int Port => _config.Port;
 
         /// <summary>
+        /// IP-Address of this listener
+        /// </summary>
+        internal IPAddress Address { get; private set; }
+
+        /// <summary>
         /// Flag if incoming connections always need to validate the first message before assigning them
         /// </summary>
         internal bool ValidateBeforeAssignment => _config.ValidateBeforeAssignment;
@@ -87,6 +93,11 @@ namespace Moryx.Communication.Sockets
         public void Initialize(BinaryConnectionConfig config)
         {
             _config = (TcpListenerConfig)config;
+
+            if (IPAddress.TryParse(_config.IpAdress, out var address))
+                Address = address;
+            else
+                Address = IPAddress.Any; // Use previous behavior as fallback
 
             StateMachine.Initialize(this).With<ServerStateBase>();
         }

--- a/src/Moryx/Communication/Sockets/Server/TcpPortListener.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpPortListener.cs
@@ -16,13 +16,18 @@ namespace Moryx.Communication.Sockets
     internal class TcpPortListener
     {
         /// <summary>
-        /// 
+        /// Create new port listener
         /// </summary>
-        /// <param name="port"></param>
-        public TcpPortListener(int port)
+        public TcpPortListener(IPAddress address, int port)
         {
+            Address = address;
             Port = port;
         }
+
+        /// <summary>
+        /// IP-Address of the listener
+        /// </summary>
+        public IPAddress Address { get; }
 
         /// <summary>
         /// Port of this port listener
@@ -91,9 +96,9 @@ namespace Moryx.Communication.Sockets
             if (_listening)
                 return;
 
-            // Start tcplistener and accept clients
+            // Start tcp listener and accept clients
             if (_tcpListener == null)
-                _tcpListener = new TcpListener(new IPEndPoint(IPAddress.Any, Port));
+                _tcpListener = new TcpListener(new IPEndPoint(Address, Port));
             _tcpListener.Start();
             _tcpListener.BeginAcceptTcpClient(ClientConnected, null);
             _listening = true;

--- a/src/Tests/Moryx.Tests/Communication/PortMapTests.cs
+++ b/src/Tests/Moryx.Tests/Communication/PortMapTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Net;
+using Moryx.Communication;
+using Moryx.Communication.Sockets;
+using NUnit.Framework;
+
+namespace Moryx.Tests.Communication
+{
+    [TestFixture]
+    public class PortMapTests
+    {
+        [TestCase("192.168.0.1", "192.168.0.2", false, true)]
+        [TestCase("192.168.0.3", "192.168.0.3", false, false)]
+        [TestCase("192.168.0.4", "192.168.0.4", true, true)]
+        [TestCase("0.0.0.0", "192.168.0.5", false, false)]
+        [TestCase("0.0.0.0", "192.168.0.6", true, true)]
+        [TestCase("192.168.0.7", "0.0.0.0", false, false)]
+        [TestCase("192.168.0.8", "0.0.0.0", true, true)]
+        public void AddressValidation(string address1, string address2, bool sameProtocol, bool allowed)
+        {
+            // Arrange
+            var protocol = new DummyProtocol(7);
+            PortMap.Register(IPAddress.Parse(address1), 42, protocol);
+
+            // Act
+            var success = PortMap.Register(IPAddress.Parse(address2), 42, new DummyProtocol(sameProtocol ? 7 : 9));
+
+            // Assert
+            if (allowed)
+                Assert.IsTrue(success, "Failed to register despite different address");
+            else
+                Assert.IsFalse(success, "Should not allow registration");
+        }
+
+        [TestCase(13, 14, false, true)]
+        [TestCase(15, 16, true, true)]
+        [TestCase(17, 17, false, false)]
+        [TestCase(18, 18, true, true)]
+        public void PortValidation(int port1, int port2, bool sameProtocol, bool allowed)
+        {
+            // Arrange
+            var protocol = new DummyProtocol(7);
+            PortMap.Register(IPAddress.Parse("192.168.0.42"), port1, protocol);
+
+            // Act
+            var success = PortMap.Register(IPAddress.Parse("192.168.0.42"), port2, new DummyProtocol(sameProtocol ? 7 : 9));
+
+            // Assert
+            if (allowed)
+                Assert.IsTrue(success, "Failed to register despite different address");
+            else
+                Assert.IsFalse(success, "Should not allow registration");
+        }
+
+        private class DummyProtocol : IMessageInterpreter
+        {
+            private int ProtocolId { get; }
+
+            public DummyProtocol(int protocolId)
+            {
+                ProtocolId = protocolId;
+            }
+
+            public bool Equals(IMessageInterpreter other)
+            {
+                return ProtocolId == (other as DummyProtocol)?.ProtocolId;
+            }
+
+            public IReadContext CreateContext()
+            {
+                throw new NotImplementedException();
+            }
+
+            public byte[] SerializeMessage(BinaryMessage message)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ByteReadResult ProcessReadBytes(IReadContext context, int readBytes, Action<BinaryMessage> publishCompleteMessage)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool ErrorResponse(IReadContext context, out byte[] lastWill)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This parse the IPAddress and properly checks conflicts only for registration overlap. This allows users to use different protocols for the same port on different network adapters or IP addresses.

Closes #89.

While doing this, I noticed that part registrations are never released, even when the listener shuts down and that all connections of all modules share the same listener instance. The first might have side effects, while the other can have performance impacts due to locks. I opened #92 for this.