### PR TITLE
Throw exception for invalid IPAddress

### DIFF
--- a/src/Moryx/Communication/Sockets/Server/TcpListenerConnection.cs
+++ b/src/Moryx/Communication/Sockets/Server/TcpListenerConnection.cs
@@ -97,7 +97,7 @@ namespace Moryx.Communication.Sockets
             if (IPAddress.TryParse(_config.IpAdress, out var address))
                 Address = address;
             else
-                Address = IPAddress.Any; // Use previous behavior as fallback
+                throw new FormatException($"Failed to parse IPAddress: {_config.IpAdress}");
 
             StateMachine.Initialize(this).With<ServerStateBase>();
         }


### PR DESCRIPTION
In #93 we had to provide fallback behavior for invalid IPAddress. In the next major we require a correctly formatted address.