### PR TITLE
Separated Initialize from IConfiguredPlugin into new IConfiguredInitializable

### DIFF
--- a/src/Moryx.Container/ComponentSelectors/ConfigBasedComponentSelector.cs
+++ b/src/Moryx.Container/ComponentSelectors/ConfigBasedComponentSelector.cs
@@ -22,7 +22,7 @@ namespace Moryx.Container
         /// </summary>
         /// <param name="method">Method invoked on the factory - normally a create method like Create(T config, ....)</param>
         /// <param name="arguments">Argument array that must have the components config as the first parameter.</param>
-        /// <returns>Name of interface implemenation</returns>
+        /// <returns>Name of interface implementation</returns>
         protected override string GetComponentName(MethodInfo method, object[] arguments)
         {
             var config = (IPluginConfig)arguments[0];
@@ -44,9 +44,9 @@ namespace Moryx.Container
 
                 var config = additionalArguments["config"];
                 var configType = config.GetType();
-                var genericPluginApi = typeof(IConfiguredPlugin<>).MakeGenericType(configType);
+                var genericPluginApi = typeof(IConfiguredInitializable<>).MakeGenericType(configType);
 
-                var initMethod = genericPluginApi.GetMethod(nameof(IConfiguredPlugin<IPluginConfig>.Initialize), new[] { configType });
+                var initMethod = genericPluginApi.GetMethod(nameof(IConfiguredInitializable<IPluginConfig>.Initialize), new[] { configType });
                 initMethod.Invoke(instance, new[] { config });
                 return instance;
             });

--- a/src/Moryx.Tools.Wcf/Service/BasicWcfConnectorPlugin.cs
+++ b/src/Moryx.Tools.Wcf/Service/BasicWcfConnectorPlugin.cs
@@ -42,7 +42,7 @@ namespace Moryx.Tools.Wcf
 
         #endregion
 
-        /// <seealso cref="IConfiguredPlugin{T}.Initialize"/>
+        /// <seealso cref="IConfiguredInitializable{T}.Initialize"/>
         public virtual void Initialize(TConfig config)
         {
             Config = config;

--- a/src/Moryx/Modules/IConfiguredInitializable.cs
+++ b/src/Moryx/Modules/IConfiguredInitializable.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2021, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+namespace Moryx.Modules
+{
+    /// <summary>
+    /// This generic interface is intended for all components that require a configuration for their initialization to work properly.
+    /// This configuration is passed to the plugin via the Initialize(TConf config) method.
+    /// </summary>
+    public interface IConfiguredInitializable<in T>
+        where T : IPluginConfig
+    {
+        /// <summary>
+        /// Initialize this component with its config
+        /// </summary>
+        /// <param name="config">Config of this component</param>
+        void Initialize(T config);
+    }
+}

--- a/src/Moryx/Modules/IConfiguredPlugin.cs
+++ b/src/Moryx/Modules/IConfiguredPlugin.cs
@@ -4,16 +4,11 @@
 namespace Moryx.Modules
 {
     /// <summary>
-    /// This generic interface is intended for all plugins that require a configuration for their initialization to work properly. 
-    /// This configuration is passed to the plugin via the Initialize(TConf config) method. 
+    /// This generic interface is intended for all plugins that require a configuration for their initialization to work properly.
+    /// This configuration is passed to the plugin via the Initialize(TConf config) method.
     /// </summary>
-    public interface IConfiguredPlugin<in T> : IPlugin
+    public interface IConfiguredPlugin<in T> : IPlugin, IConfiguredInitializable<T>
         where T : IPluginConfig
     {
-        /// <summary>
-        /// Initialize this component with its config
-        /// </summary>
-        /// <param name="config">Config of this module plugin</param>
-        void Initialize(T config);
     }
 }

--- a/src/Moryx/Serialization/PossibleValues/PluginConfigsAttribute.cs
+++ b/src/Moryx/Serialization/PossibleValues/PluginConfigsAttribute.cs
@@ -70,7 +70,7 @@ namespace Moryx.Serialization
             var possibleValues = new List<Type>();
             if (_exportBaseType)
             {
-                var baseConfig = StrategyService.GetInterface(typeof(IConfiguredPlugin<>).Name).GetGenericArguments()[0];
+                var baseConfig = StrategyService.GetInterface(typeof(IConfiguredInitializable<>).Name).GetGenericArguments()[0];
                 if (!baseConfig.IsAbstract)
                     possibleValues.Add(baseConfig);
             }

--- a/src/TestModule/Plugin/ITestSubPlugin.cs
+++ b/src/TestModule/Plugin/ITestSubPlugin.cs
@@ -7,6 +7,6 @@ namespace Moryx.TestModule
 {
     public interface ITestSubPlugin : IConfiguredPlugin<TestSubPluginConfig>
     {
-         
+
     }
 }


### PR DESCRIPTION
Sometimes the plugin methods are too much for a component where just a configuration is enough. I separated the interfaces.